### PR TITLE
chore(sxmc-283): Add auto merge for dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @alkemics/sxm-core
+go.mod @alkemics/sxm-core @lucyalkemics
+go.sum @alkemics/sxm-core @lucyalkemics

--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,2 @@
+- dependency-type: all
+  update-type: minor

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Problem
+
+[Jira ticket](https://salsify.atlassian.net/browse/SXMC-XXXX)
+
+<!-- Brief description of the problems that pertain to the PR -->
+
+## Solution
+
+<!-- Describe your solution to the problem proposed in the PR] -->
+
+## Caveats/Notes
+
+<!-- Note any caveats or other notes for the reviewer] -->
+
+Prime:
+
+cc @alkemics/sxm-core


### PR DESCRIPTION
## Problem
[Jira ticket](https://salsify.atlassian.net/browse/SXMC-283)

With dependabot enabled for most repos, we now want to activate auto-merge for all patch and minor versions.

## Solution
Add/change the corresponding config file(s)

Prime: @alkemics/sxm-core
