### PR TITLE
chore(deps): Remove dependabot execution time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "04:00"
     open-pull-requests-limit: 2


### PR DESCRIPTION
## Problem
Currently over 30 repos are running their dependabot executions at 4 am. This means that when a common dependency is released it will trigger a lot of pipeline jobs, meaning a lot of Pillars are created and the system is not ready to handle that kind of load leading to failed executions by timeout or anything of the sort.

## Solution
Remove the 4 am configuration to let dependabot run at random times, hopefully minimizing the effect of the pipelines running.

Prime: anyone from @alkemics/sxm-core 
