### PR TITLE
feat(SXMC-1012): Update go to version 1.21

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.19
+          go-version: 1.21
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.19
+          go-version: 1.21
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.19
+          go-version: 1.21
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alkemics/goflow
 
-go 1.19
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
## Problem

[Jira ticket](https://salsify.atlassian.net/browse/SXMC-1012)

We need to update the Go versions of our repos to 1.23. 

## Solution
This repo was still in 1.19 and trying to update to 1.23 is causing a lot of issues with the tests. So this is a first increment till the last "compatible" version, which is 1.21.

Prime: @alkemics/sxm-core