### PR TITLE
chore(SXMC-1012): use latest available go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/alkemics/goflow
 
-go 1.23.0
-
-toolchain go1.23.8
+go 1.23.8
 
 require (
 	github.com/stretchr/testify v1.8.2


### PR DESCRIPTION
Following up on go 1.23 upgrade
Use latest available version (and remove the toolchain dependency accordingly)