### PR TITLE
chore(SXMC-1776): update ci orb to version 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ci: alkemics/ci@3
+  ci: alkemics/ci@4
 
 aliases:
   - filter-PR-only: &PR-only


### PR DESCRIPTION
## Problem
[SXMC-1776](https://salsify.atlassian.net/browse/SXMC-1776)

Update the alkemics/ci orb to version 4.

## Solution
Bump `alkemics/ci@4` in `.circleci/config.yml`.

## Caveats/Notes
_None_

cc @alkemics/sxm-core

[SXMC-1776]: https://salsify.atlassian.net/browse/SXMC-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ