### PR TITLE
chore(SXMC-1494): Upgrade Go & CCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ci: alkemics/ci@4
+  ci: alkemics/ci@5
 
 aliases:
   - filter-PR-only: &PR-only

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -11,13 +11,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.23
-        id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+        id: go
       - name: Get dependencies
         run: go mod download
       - name: Test
@@ -30,22 +30,15 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.23
-        id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-      - name: Restore GolangCI-Lint Cache
-        uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          path: ~/.cache/golangci-lint
-          key: golangci-lint.cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            golangci-lint.cache-${{ runner.os }}-
+          go-version-file: go.mod
+        id: go
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
       - name: Check diffs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.23
+          go-version: 1.26
         id: go
 
       - name: Check out code into the Go module directory

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
+version: "2"
+
 run:
-  deadline: 8m
+  timeout: 8m
   build-tags:
     - codeanalysis
 
@@ -9,5 +11,8 @@ linters:
     - nolintlint # Reports ill-formed or insufficient nolint directives
     - unconvert # Remove unnecessary type conversions
     - whitespace # Tool for detection of leading and trailing whitespace
-    - gofumpt # Gofumpt checks whether code was gofumpt-ed
     - prealloc # Finds slice declarations that could potentially be preallocated
+
+formatters:
+  enable:
+    - gofumpt # Gofumpt checks whether code was gofumpt-ed

--- a/errors.go
+++ b/errors.go
@@ -24,7 +24,7 @@ func (e Error) Unwrap() error {
 
 func (e Error) Format(s fmt.State, verb rune) {
 	if verb != 'v' || (!s.Flag('+')) {
-		fmt.Fprint(s, e.Error())
+		fmt.Fprint(s, e.Error()) //nolint:errcheck
 		return
 	}
 
@@ -40,7 +40,7 @@ func (e Error) Format(s fmt.State, verb rune) {
 		errMsg = strings.Join(strs, "\n")
 	}
 
-	fmt.Fprintf(s, `%s:
+	_, _ = fmt.Fprintf(s, `%s:
 %v
 `,
 		e.Filename,

--- a/example/generator/main.go
+++ b/example/generator/main.go
@@ -110,7 +110,7 @@ func main() {
 			continue
 		}
 
-		if err := os.WriteFile(generatedFilename, buf.Bytes(), 0o600); err != nil {
+		if err := os.WriteFile(generatedFilename, buf.Bytes(), 0o600); err != nil { //nolint:gosec
 			genErrs = append(genErrs, err)
 		}
 

--- a/gfutil/dependencies_test.go
+++ b/gfutil/dependencies_test.go
@@ -56,7 +56,7 @@ func (n dependencyNode) Run(inputs, outputs []goflow.Field) (string, error) { re
 func (s *DependenciesSuite) TestSortNode() {
 	s.dependencyMap["d'"] = []string{"b", "c"}
 
-	nodes := make([]goflow.NodeRenderer, 0)
+	nodes := make([]goflow.NodeRenderer, 0, len(s.dependencyMap))
 	for id, deps := range s.dependencyMap {
 		nodes = append(nodes, dependencyNode{
 			id:   id,

--- a/gfutil/gfgo/json.go
+++ b/gfutil/gfgo/json.go
@@ -59,7 +59,7 @@ func WithJSONMarshal(
 	yamlFilename string,
 	nodes []Node,
 ) GenerateFunc {
-	file, err := os.Open(yamlFilename)
+	file, err := os.Open(yamlFilename) //nolint:gosec
 	if err != nil {
 		return func(w io.Writer, g goflow.GraphRenderer) error {
 			return err

--- a/gfutil/gfgo/nodes.go
+++ b/gfutil/gfgo/nodes.go
@@ -413,6 +413,7 @@ func parseTypesDoc(pkg *packages.Package) (map[string]string, error) {
 		return nil, nil
 	}
 
+	//nolint:staticcheck // SA1019: parser.ParseDir is deprecated since Go 1.25; TODO: migrate to golang.org/x/tools/go/packages
 	pkgs, err := parser.ParseDir(pkg.Fset, path.Dir(pkg.GoFiles[0]), nil, parser.ParseComments)
 	if err != nil {
 		return nil, err

--- a/gfutil/gfgo/parsing.go
+++ b/gfutil/gfgo/parsing.go
@@ -15,7 +15,7 @@ func ParseType(typ types.Type) (string, []goflow.Import, error) {
 	// Replace the full packages names with their name.
 	t := typ.String()
 	for i, imp := range imports {
-		t = strings.Replace(t, imp.Dir, imp.Pkg, -1)
+		t = strings.ReplaceAll(t, imp.Dir, imp.Pkg)
 		// TODO: check this when we migrate to modules.
 		if strings.Contains(imp.Dir, "/vendor/") {
 			imports[i].Dir = imp.Dir[strings.Index(imp.Dir, "/vendor/")+8:]

--- a/gfutil/gfgo/testutil.go
+++ b/gfutil/gfgo/testutil.go
@@ -76,7 +76,7 @@ func TestGenerate(t *testing.T, wrappers []goflow.GraphWrapper, filename string,
 	require.NoError(w.Flush())
 
 	if _, err := os.Open("graph"); os.IsNotExist(err) {
-		require.NoError(os.Mkdir("graph", 0o755))
+		require.NoError(os.Mkdir("graph", 0o750))
 	} else if err != nil {
 		require.NoError(err)
 	}

--- a/gfutil/gfgo/writer.go
+++ b/gfutil/gfgo/writer.go
@@ -48,7 +48,7 @@ func (w *Writer) Flush() error {
 		return err
 	}
 
-	src, err = format.Source(src, format.Options{LangVersion: "1.23"})
+	src, err = format.Source(src, format.Options{LangVersion: "1.26"})
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alkemics/goflow
 
-go 1.23.8
+go 1.26
 
 require (
 	github.com/stretchr/testify v1.8.2

--- a/run.go
+++ b/run.go
@@ -14,7 +14,7 @@ import (
 //
 // It also logs the time taken since start, because why not.
 func WriteFile(content, filename string, start time.Time) error {
-	before, err := os.ReadFile(filename)
+	before, err := os.ReadFile(filename) //nolint:gosec
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -25,13 +25,17 @@ func WriteFile(content, filename string, start time.Time) error {
 
 	created := os.IsNotExist(err)
 
-	wf, err := os.OpenFile(filename, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0o600)
+	wf, err := os.OpenFile(filename, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0o600) //nolint:gosec
 	if err != nil {
 		return err
 	}
-	defer wf.Close()
 
 	if _, err := wf.WriteString(content); err != nil {
+		_ = wf.Close()
+		return err
+	}
+
+	if err := wf.Close(); err != nil {
 		return err
 	}
 

--- a/yaml.go
+++ b/yaml.go
@@ -11,14 +11,14 @@ import (
 //
 // Even if a wrapper returns an error, this function will go through all the wrappers.
 func Load(yamlFilename string, wrappers []GraphWrapper) (GraphRenderer, error) {
-	file, err := os.Open(yamlFilename)
+	file, err := os.Open(yamlFilename) //nolint:gosec
 	if err != nil {
 		return nil, Error{
 			Filename: yamlFilename,
 			Err:      err,
 		}
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
 	var g graphLoader
 	if err := yaml.NewDecoder(file).Decode(&g); err != nil {


### PR DESCRIPTION
## Problem

[Jira ticket](https://salsify.atlassian.net/browse/SXMC-1494)

- Support ended for golang 1.23 in August 2025; for 1.24 in February 2026.
- A new CCI orb was released.

## Solution

- Upgrade golang to most recent supported version (1.26).
- Upgrade CCI orb to v5.

## Caveats

This Go upgrade was a bit more complicated than the others.

- Several dependencies needed to be bumped to be compatible with the new Go version (Github Actions, golang-ci-lint-action)
- The bump in golangci-lint had a breaking change, requiring gofumpt to be moved to formatters
- The linter bump also caused several linter violations which I either ignored with //nolint comments or fixed with the help of Claude.

Prime: @alk-jtessier 

cc @alkemics/sxm-core
